### PR TITLE
Update version of official schema

### DIFF
--- a/hh-gml/official-schema-validation.md
+++ b/hh-gml/official-schema-validation.md
@@ -8,7 +8,7 @@
 
 **Test method**
 
-* Validate each document against the latest INSPIRE official schema(s): https://inspire.ec.europa.eu/schemas/hh/4.0/HumanHealth.xsd, using strict XML schema validation.
+* Validate each document against the latest INSPIRE official schema(s): https://inspire.ec.europa.eu/schemas/hh/5.0/HumanHealth.xsd, using strict XML schema validation.
 
 **Reference(s)**: 
 


### PR DESCRIPTION
The version of the official schema(s) was updated according to the latest application schema release (https://github.com/INSPIRE-MIF/application-schemas/releases/tag/2024.1).
See the related validator issue for reference: https://github.com/INSPIRE-MIF/helpdesk-validator/issues/1027